### PR TITLE
Update ThapNienHenUoc ticket purchase links for HN and HCM

### DIFF
--- a/ThapNienHenUoc/index.html
+++ b/ThapNienHenUoc/index.html
@@ -1446,7 +1446,7 @@ Nguồn tài nguyên & Thư viện sử dụng:
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-12">
                     <!-- HÀ NỘI MISSION CARD -->
-                    <a href="#" target="_blank"
+                    <a href="https://buy.worldsimp.com/events/11" target="_blank"
                         class="relative group block transform -skew-x-6 hover:-translate-y-2 transition-all duration-500 overflow-hidden rounded-3xl border-4 border-gray-800 hover:border-secondary shadow-[0_10px_30px_rgba(0,0,0,0.2)] hover:shadow-[0_0_40px_rgba(239,68,68,0.5)] ticket-btn">
                         <!-- Background Image Container -->
                         <div class="absolute inset-0 z-0 bg-gray-900">
@@ -1504,7 +1504,7 @@ Nguồn tài nguyên & Thư viện sử dụng:
                     </a>
 
                     <!-- HỒ CHÍ MINH MISSION CARD -->
-                    <a href="#" target="_blank"
+                    <a href="https://buy.worldsimp.com/events/10" target="_blank"
                         class="relative group block transform -skew-x-6 hover:-translate-y-2 transition-all duration-500 overflow-hidden rounded-3xl border-4 border-gray-800 hover:border-secondary shadow-[0_10px_30px_rgba(0,0,0,0.2)] hover:shadow-[0_0_40px_rgba(239,68,68,0.5)] ticket-btn">
                         <!-- Background Image Container -->
                         <div class="absolute inset-0 z-0 bg-gray-900">


### PR DESCRIPTION
### Motivation
- Ensure the mission cards on the ThapNienHenUoc page link to the correct Worldsimp event pages for Hà Nội and Hồ Chí Minh so users can purchase tickets.

### Description
- Replaced the Hà Nội mission card `href` in `ThapNienHenUoc/index.html` from `#` to `https://buy.worldsimp.com/events/11`.
- Replaced the Hồ Chí Minh mission card `href` in `ThapNienHenUoc/index.html` from `#` to `https://buy.worldsimp.com/events/10`.
- Modified a single file (`ThapNienHenUoc/index.html`) with `2 insertions(+), 2 deletions(-)` and committed the change.

### Testing
- Ran `rg -n "buy|href|events" ThapNienHenUoc` to locate updated links, which succeeded.
- Verified the exact changes with `git -C /workspace/wlh-ticket diff -- ThapNienHenUoc/index.html`, which showed the intended replacements and succeeded.
- Inspected the updated lines with `nl -ba ThapNienHenUoc/index.html | sed -n '1442,1512p'` to confirm the new `href` values, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a104f333b04832ab6511a29bca92913)