### PR TITLE
Add Cloudflare Web Analytics beacon to ThapNienHenUoc page

### DIFF
--- a/ThapNienHenUoc/index.html
+++ b/ThapNienHenUoc/index.html
@@ -632,6 +632,7 @@ Nguồn tài nguyên & Thư viện sử dụng:
             animation: border-alert 0.8s ease-in-out infinite;
         }
     </style>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "795167730d2e454d86b8056d43cf0b81"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 
 <body


### PR DESCRIPTION
### Motivation
- Enable Cloudflare Web Analytics on the `ThapNienHenUoc` page by inserting the Cloudflare beacon script into the HTML head so analytics load on page render.

### Description
- Inserted the Cloudflare Web Analytics script snippet immediately before the closing `</head>` tag in `ThapNienHenUoc/index.html` (single-line `<script defer ... beacon.min.js ...>` insertion).

### Testing
- Ran the insertion script (`python - <<'PY' ...`) and verified the snippet appears in the file, checked repository state with `git status --short`, committed the change with `git commit`, and inspected the file region with `nl -ba ThapNienHenUoc/index.html | sed -n '628,642p'`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11990236f0832ab6f5d09ba05b7bd1)