### PR TITLE
Add Cloudflare Web Analytics beacon to site HTML pages

### DIFF
--- a/DrivinIntoDream/index.html
+++ b/DrivinIntoDream/index.html
@@ -84,6 +84,7 @@
             background-size: 20px 20px;
         }
     </style>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "795167730d2e454d86b8056d43cf0b81"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 
 <body

--- a/ThapNienHenUoc/index.html
+++ b/ThapNienHenUoc/index.html
@@ -632,6 +632,7 @@ Nguồn tài nguyên & Thư viện sử dụng:
             animation: border-alert 0.8s ease-in-out infinite;
         }
     </style>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "795167730d2e454d86b8056d43cf0b81"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 
 <body

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <script>
     window.location.replace("/ThapNienHenUoc/");
   </script>
+<!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "795167730d2e454d86b8056d43cf0b81"}'></script><!-- End Cloudflare Web Analytics -->
 </head>
 <body>
   <p>Nếu bạn không được chuyển hướng tự động, vui lòng <a href="/ThapNienHenUoc/">nhấn vào đây</a>.</p>


### PR DESCRIPTION
### Motivation
- Add Cloudflare Web Analytics to enable basic traffic monitoring for the site.

### Description
- Inserted the Cloudflare Insights beacon script (`https://static.cloudflareinsights.com/beacon.min.js`) into the `<head>` of `index.html`, `DrivinIntoDream/index.html`, and `ThapNienHenUoc/index.html`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11990236f0832ab6f5d09ba05b7bd1)